### PR TITLE
Add incoming/outgoing commands

### DIFF
--- a/bin/gitscape
+++ b/bin/gitscape
@@ -44,6 +44,8 @@ The following actions are supported.
                                   release branch into live and master. Tags are created that
                                   facilitate a rollback.
                                   ** These actions update the origin server. **
+  incoming                        See incoming commits that aren't in your working copy.
+  outgoing                        See outgoing commits before merging them.
 EOS
 
 # Parse option overrides.
@@ -103,6 +105,10 @@ else
       Gitscape::Base.new.release_finish options
     when "tag_cleanup"
       Gitscape::Base.new.tag_cleanup options
+    when "incoming"
+      Gitscape::Base.new.incoming
+    when "outgoing"
+      Gitscape::Base.new.outgoing
     else
       puts "Unknown command: #{command_name}"
   end

--- a/lib/gitscape/base.rb
+++ b/lib/gitscape/base.rb
@@ -372,6 +372,15 @@ class Gitscape::Base
     tags_to_delete.each { |tag| puts `git push origin :refs/tags/#{tag}` } if options[:push]
   end
 
+  #Source: http://stackoverflow.com/a/20471036/1904232
+  def incoming
+    puts `git fetch && git log ..origin/master --stat`
+  end
+
+  def outgoing
+    puts `git fetch && git log origin/master.. --stat`
+  end
+
   # Returns true if the supplied Git commit hash or reference exists
   def self.commit_exists?(commit_id)
     `git rev-parse #{commit_id}`

--- a/lib/gitscape/version.rb
+++ b/lib/gitscape/version.rb
@@ -1,3 +1,3 @@
 module Gitscape
-  VERSION = '1.7.3'
+  VERSION = '1.7.4'
 end


### PR DESCRIPTION
Mercurial (hg) offers this methods to see what you'll get from the remote before doing `git pull` or `git push`. This is specially helpful when local commits might be impacted by that pull.