### PR TITLE
Colorized output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ To test, you must build and install the new version locally
 Note that the "bundle" command is configured to install the gem from the local copy.
 
 You must use "bundle exec gitscape" to test locally.
+
+This requires git >= 2.4.6. Verify with `git --version`

--- a/lib/gitscape/version.rb
+++ b/lib/gitscape/version.rb
@@ -1,3 +1,3 @@
 module Gitscape
-  VERSION = '1.7.3'
+  VERSION = '1.7.4'
 end


### PR DESCRIPTION
This should address #3 . The problem is git config value detects it's talking to puts and passes a de-colorized output. Adding an override flag to each command seems to fix it.

We might want to do it in a convenience method or push the global value and remove it afterwards?